### PR TITLE
Amended keycard access to read more as a privilege than right

### DIFF
--- a/TheOpensourceClubConstitution-2013-19-02.tex
+++ b/TheOpensourceClubConstitution-2013-19-02.tex
@@ -42,7 +42,7 @@
 	\end{itemize}
 	\subsection{Part 2 - Membership Privileges}
 
-	Accounts on the club computers can be given out to any member who requests an account, provided Ohio State University's rules are followed.  These accounts may be revoked due to inactivity or failure to follow the rules.  Key card access to the club office can be granted after a member has been active within the club for at least two months, provided that Ohio State University rules are followed.  Access may be revoked due to inactivity or failure to follow the rules.
+	Accounts on the club computers can be given out to any member who requests an account, provided Ohio State University's rules are followed.  These accounts may be revoked due to inactivity or failure to follow the rules.  Key card access to the club office can be granted on request given the consent of the president, provided that Ohio State University rules are followed.  Access may be revoked due to inactivity or failure to follow the rules.
 	When it is necessary to take a vote, voting members are allowed to do so.
 
 	\subsection{Part 3 - Membership Removal}

--- a/TheOpensourceClubConstitution-2013-19-02.tex
+++ b/TheOpensourceClubConstitution-2013-19-02.tex
@@ -42,7 +42,7 @@
 	\end{itemize}
 	\subsection{Part 2 - Membership Privileges}
 
-	Accounts on the club computers will be given out to any member who requests an account, provided Ohio State University's rules are followed.  These accounts may be revoked due to inactivity or failure to follow the rules.  Key card access to the club office will be granted after a member has been active within the club for at least two months, provided that Ohio State University rules are followed.  Access may be revoked due to inactivity or failure to follow the rules.
+	Accounts on the club computers will be given out to any member who requests an account, provided Ohio State University's rules are followed.  These accounts may be revoked due to inactivity or failure to follow the rules.  Key card access to the club office can be granted after a member has been active within the club for at least two months, provided that Ohio State University rules are followed.  Access may be revoked due to inactivity or failure to follow the rules.
 	When it is necessary to take a vote, voting members are allowed to do so.
 
 	\subsection{Part 3 - Membership Removal}

--- a/TheOpensourceClubConstitution-2013-19-02.tex
+++ b/TheOpensourceClubConstitution-2013-19-02.tex
@@ -42,7 +42,7 @@
 	\end{itemize}
 	\subsection{Part 2 - Membership Privileges}
 
-	Accounts on the club computers will be given out to any member who requests an account, provided Ohio State University's rules are followed.  These accounts may be revoked due to inactivity or failure to follow the rules.  Key card access to the club office can be granted after a member has been active within the club for at least two months, provided that Ohio State University rules are followed.  Access may be revoked due to inactivity or failure to follow the rules.
+	Accounts on the club computers can be given out to any member who requests an account, provided Ohio State University's rules are followed.  These accounts may be revoked due to inactivity or failure to follow the rules.  Key card access to the club office can be granted after a member has been active within the club for at least two months, provided that Ohio State University rules are followed.  Access may be revoked due to inactivity or failure to follow the rules.
 	When it is necessary to take a vote, voting members are allowed to do so.
 
 	\subsection{Part 3 - Membership Removal}


### PR DESCRIPTION
Previously this read as if everyone is automatically added to
the office swipe list upon being active for two months