### PR TITLE
Changed all references of quarters to semesters

### DIFF
--- a/TheOpensourceClubConstitution-2013-19-02.tex
+++ b/TheOpensourceClubConstitution-2013-19-02.tex
@@ -3,7 +3,7 @@
 \documentclass{article}
 \title{The Opensource Club Constitution}
 \author{Isaac Jones -- Martin Jansche -- Michael Benedict}
-\date{20 March, 2000\\ Updated 24 March 2016}
+\date{20 March, 2000\\ Updated 17 August 2016}
 \setcounter{secnumdepth}{0}
 \usepackage[normalem]{ulem}
 \usepackage{graphicx}
@@ -82,7 +82,7 @@
 	The Treasurer shall the following responsibilities:
 
 	\begin{itemize}
-		\item Produces and presents a quarterly budget
+		\item Produces and presents a semesterly budget
 		\item Purchases pizza and other consumables for meetings
 		\item Represents our club at E-Council
 		\item Produces and Submits applications for funding
@@ -97,7 +97,7 @@
 	\subsection{Part 3 - Officer Removal}
 
 	Leadership is needed in any club and so officers are required to be
-present at eight out of ten official meetings per quarter, while it is also
+present at eight out of ten official meetings per semester, while it is also
 realized that extenuating circumstances are possible.  In order to eliminate
 doubts surrounding an officers excuse for missing a meeting, said officer
 must notify at least one of the other officers that they will not be in


### PR DESCRIPTION
Resolves #9. Still requires a vote though to amend add these changes. We might stage this for the election meeting in Spring semester to keep bureaucracy to a minimum concise time-period especially given how this is a non-critical issue.